### PR TITLE
Fix cabal files.

### DIFF
--- a/hode-ui/hode-ui.cabal
+++ b/hode-ui/hode-ui.cabal
@@ -24,7 +24,7 @@ library
                   Hode.UI.BufferShow
                 , Hode.UI.BufferTree
                 , Hode.UI.Clipboard
-                , Hode.UI.CycleBreaker
+                , Hode.UI.CycleBuffer
                 , Hode.UI.ExprTree
                 , Hode.UI.ExprTree.Sort
                 , Hode.UI.Help

--- a/hode/hode.cabal
+++ b/hode/hode.cabal
@@ -36,7 +36,7 @@ library
                 , Hode.Hash.Lookup
                 , Hode.Hash.Lookup.Transitive
                 , Hode.Hash.Parse
---                , Hode.Hash.Parse.Keywords -- imported qualified in .ghci
+                , Hode.Hash.Parse.Keywords
                 , Hode.Hash.Parse.Util
                 , Hode.Hash.Types
                 , Hode.Hash.Util


### PR DESCRIPTION
I cannot build the package. There are 2 errors, one in `hode-ui/hode-ui.cabal` and one in `hode/hode.cabal`.

I am building with Cabal, so maybe that is the cause of the issue. Anyway, after these trivial adjustments everything builds and the application runs via `cabal run hode-ui:hode-exe`.