### PR TITLE
fixup! Rename   Hode.Hash.Convert -> Hode.Hash.MkHExpr

### DIFF
--- a/hode/hode.cabal
+++ b/hode/hode.cabal
@@ -31,7 +31,7 @@ library
                 , Hode.Data.Map
 --                , Hode.Data.Relation
 
-                , Hode.Hash.Convert
+                , Hode.Hash.MkHExpr
                 , Hode.Hash.EitherExpr
                 , Hode.Hash.Hash
                 , Hode.Hash.Lookup


### PR DESCRIPTION
I observed the following failure:

```
% cabal run hode-ui:hode-exe
Build profile: -w ghc-8.10.4 -O1
In order, the following will be built (use -v for more details):
 - hode-0.1.0.0 (lib) (first run)
 - hode-ui-0.1.0.0 (lib) (first run)
 - hode-ui-0.1.0.0 (exe:hode-exe) (first run)
Preprocessing library for hode-0.1.0.0..
cabal-3.4.0.0: can't find source for Hode/Hash/Convert in .,
/srv/src/hode/dist-newstyle/build/x86_64-linux/ghc-8.10.4/hode-0.1.0.0/build/autogen,
/srv/src/hode/dist-newstyle/build/x86_64-linux/ghc-8.10.4/hode-0.1.0.0/build/global-autogen

cabal: Failed to build hode-0.1.0.0 (which is required by exe:hode-exe from
hode-ui-0.1.0.0).

```

The cause was obvious and the patch is trivial. Looks like someone forgot to commit this change.