### PR TITLE
Feature: Cabal.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ./hode-ui/hode-ui.cabal ./hode-test/hode-test.cabal ./hode/hode.cabal

--- a/hode/hode.cabal
+++ b/hode/hode.cabal
@@ -101,7 +101,7 @@ library
               , pointedlist
               , pretty-simple
               , process
-              , recursion-schemes
+              , recursion-schemes <= 5.1.3
               , text
                 , regex-compat
               , vector


### PR DESCRIPTION
Support building with Cabal.

See for yourself: `cabal run hode-ui:hode-exe`.

Resolves #16 along the way.

A fortunate side of using Cabal is that `brick` and `vty` work out of the box.